### PR TITLE
Fix parsing chapterDetails for ArangScans

### DIFF
--- a/src/ArangScans/ArangScans.ts
+++ b/src/ArangScans/ArangScans.ts
@@ -4,7 +4,7 @@ import {Madara} from '../Madara'
 const ARANGSCANS_DOMAIN = "https://arangscans.com"
 
 export const ArangScansInfo: SourceInfo = {
-    version: '1.1.1',
+    version: '1.1.2',
     name: 'ArangScans',
     description: 'Extension that pulls manga from arangscans.com',
     author: 'GameFuzzy',

--- a/src/ArangScans/ArangScans.ts
+++ b/src/ArangScans/ArangScans.ts
@@ -24,4 +24,5 @@ export class ArangScans extends Madara {
     baseUrl: string = ARANGSCANS_DOMAIN
     languageCode: LanguageCode = LanguageCode.ENGLISH
     userAgentRandomizer = ''
+    chapterDetailsParam = "?style=list"
 }

--- a/src/Madara.ts
+++ b/src/Madara.ts
@@ -44,6 +44,14 @@ export abstract class Madara extends Source {
     hasAdvancedSearchPage: boolean = false
 
     /**
+     * Different Madara sources might require a extra param in order for the images to be parsed.
+     * Eg. for https://arangscans.com/manga/tesla-note/chapter-3/?style=list "?style=list" would be the param
+     * added to the end of the URL. This will set the page in list style and is needed in order for the
+     * images to be parsed. Params can be addded if required.
+     */
+    chapterDetailsParam: string = ""
+
+    /**
      * Different Madara sources might have a slightly different selector which is required to parse out
      * each page while on a chapter page. This is the selector
      * which is looped over. This may be overridden if required.
@@ -102,7 +110,7 @@ export abstract class Madara extends Source {
             method: 'GET',
             headers: this.constructHeaders({}),
             cookies: [createCookie({name: 'wpmanga-adault', value: "1", domain: this.baseUrl})],
-            param: "?style=list"
+            param: this.chapterDetailsParam
         })
 
         let data = await this.requestManager.schedule(request, 1)

--- a/src/Madara.ts
+++ b/src/Madara.ts
@@ -101,7 +101,8 @@ export abstract class Madara extends Source {
             url: `${this.baseUrl}/${this.sourceTraversalPathName}/${chapterId}/`,
             method: 'GET',
             headers: this.constructHeaders({}),
-            cookies: [createCookie({name: 'wpmanga-adault', value: "1", domain: this.baseUrl})]
+            cookies: [createCookie({name: 'wpmanga-adault', value: "1", domain: this.baseUrl})],
+            param: "?style=list"
         })
 
         let data = await this.requestManager.schedule(request, 1)


### PR DESCRIPTION
Added the ?style=list param to the getChapterDetails request. Doesn't seem to conflict with any other source as of now.
Passed all tests for all sources.